### PR TITLE
Added docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,17 @@ RUN npm install --global pnpm && \
     pnpm install -g pm2 && \
     mkdir /app/config
 
+# Install nginx
+RUN apt-get update && \
+    apt-get install -y nginx && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /etc/nginx/sites-enabled/default && \
+    rm -rf /etc/nginx/sites-available/default && \
+    rm -rf /etc/nginx/nginx.conf
+
+# Add nginx config
+COPY config/nginx.conf /etc/nginx/nginx.conf
+
 # Add src
 COPY assets assets
 COPY config/default.json config/default.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:16.15.1
+
+# Set environment variables
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="${PATH}:${PNPM_HOME}"
+WORKDIR /app
+
+# Install dependencies
+RUN npm install --global pnpm && \
+    SHELL=bash pnpm setup && \
+    pnpm install -g pm2 && \
+    mkdir /app/config
+
+# Add src
+COPY assets assets
+COPY config/default.json config/default.json
+COPY packages packages
+COPY entrypoint.sh entrypoint.sh
+COPY package.json package.json
+COPY tsconfig.json tsconfig.json
+COPY tsconfig.base.json tsconfig.base.json
+COPY tsconfig.project.json tsconfig.project.json
+COPY pnpm-workspace.yaml pnpm-workspace.yaml
+
+# Build
+RUN pnpm i
+RUN pnpm run build && \
+    chmod +x entrypoint.sh
+
+CMD [ "./entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Keagate *(&#107;&#105;&colon;&#103;&#101;&#618;&#116;)* – A High-Performance 
   * [Purpose](#purpose)
 * [Installation](#installation)
   * [One-liner](#one-liner)
+  * [Docker Compose](#docker-compose)
   * [Manual](#manual-installation)
 * [Configuration](#configuration)
   * [CLI](#cli)
@@ -106,6 +107,30 @@ This helper script has been tested on...
 <!-- No Docker quick install on Redhat RHEL -->
 
 This script should run successfully on most flavors of Linux with some configuration. Otherwise, use the manual build, as it's fairly straightforward.
+
+### Docker compose
+
+Keagate can be run completely in Docker via Docker Compose.
+
+Get setup seeds:
+
+```bash
+docker build -t keagate .
+docker run --rm keagate node packages/scripts/build/setupSeeds.js
+```
+
+Adjust `config/local.json` as needed and make sure to set following options there:
+
+```json
+"MONGO_CONNECTION_STRING": "mongodb://db:27017",
+"HOST": "0.0.0.0"
+```
+
+Then, run the following:
+
+```bash
+docker compose up -d
+```
 
 ### Manual Installation
 

--- a/config/default.json
+++ b/config/default.json
@@ -20,5 +20,6 @@
 
     "IS_DEV": false,
     "USE_SO_CHAIN": true,
-    "PORT": 8081
+    "PORT": 8081,
+    "BIND_HOST": "127.0.0.1"
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,36 @@
+# Default nginx conf reverse proxy to 127.0.0.1
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {  
+  proxy_redirect          off;
+  proxy_set_header        Host            $host;
+  proxy_set_header        X-Real-IP       $remote_addr;
+  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  client_max_body_size    10m;
+  client_body_buffer_size 128k;
+  proxy_connect_timeout   90;
+  proxy_send_timeout      90;
+  proxy_read_timeout      90;
+  proxy_buffers           32 4k;
+
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  sendfile     on;
+  tcp_nopush   on;
+  server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+
+  server { # simple reverse-proxy
+    listen       8100;
+    server_name  _;
+
+    # pass requests for dynamic content to rails/turbogears/zope, et al
+    location / {
+      proxy_pass      http://127.0.0.1:8081;
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./config:/app/config
     ports:
-      - "8081:8081"
+      - "8081:8100"
 
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  db:
+    image: mongo
+    volumes:
+      - db:/data/db
+  app:
+    build: .
+    volumes:
+      - ./config:/app/config
+    ports:
+      - "8081:8081"
+
+    depends_on:
+      - db
+
+volumes:
+  db:
+    driver: local

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pnpm --filter "invoice-client" build
+node packages/backend/build/index.js --name "Keagate" --time

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# Start/enable nginx in docker
+service nginx start
+
 pnpm --filter "invoice-client" build
 node packages/backend/build/index.js --name "Keagate" --time

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -102,7 +102,7 @@ async function main() {
 
     await server.ready();
     server.swagger();
-    server.listen({ port: config.getTyped('PORT') }, (err, address) => {
+    server.listen({ port: config.getTyped('PORT'), host: config.getTyped('BIND_HOST') ?? '127.0.0.1' }, (err, address) => {
         if (err) {
             console.error(err);
             process.exit(1);

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -33,4 +33,6 @@ export interface MyConfig extends MyCurrencyConfig {
 
     HOST?: string;
     PORT: number;
+
+    BIND_HOST?: string;
 }


### PR DESCRIPTION
I added a simple docker-compose config with Dockerfile etc., to get Keagate running easily. Also included docs.

`BIND_HOST` is needed because otherwise, it will only listen to `127.0.0.1`, which doesn't work when forwarding from the container to the outside. This is backward compatible.

Also, thanks for this nice app :)