### PR TITLE
@keagate/common is not in the npm registry issue fixes

### DIFF
--- a/packages/api-providers/package.json
+++ b/packages/api-providers/package.json
@@ -10,7 +10,7 @@
     "clean": "shx rm -rf build pnpm-lock.yaml node_modules tsconfig.package.tsbuildinfo"
   },
   "dependencies": {
-    "@keagate/common": "^1.0.0",
+    "@keagate/common": "file:../common",
     "big.js": "^6.2.0"
   }
 }


### PR DESCRIPTION
Getting error while pnpm i 

```
Scope: all 6 workspace projects
/home/xr7/Projects/Keagate/packages/api-providers:
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@keagate%2Fcommon: Not Found - 404

This error happened while installing a direct dependency of /home/xr7/Projects/Keagate/packages/api-providers

@keagate/common is not in the npm registry, or you have no permission to fetch it.

No authorization header was set for the request.
```
